### PR TITLE
Fixed wrong cahvore model loading

### DIFF
--- a/mrcal/cameramodel.py
+++ b/mrcal/cameramodel.py
@@ -822,14 +822,20 @@ So for the purposes of extrinsics, the reference is the "left-rectified" camera
                 def load():
                     try:
                         import yaml
-                        return yaml.safe_load(modelstring)
+                        loaded = yaml.safe_load(modelstring)
+                        if not isinstance(loaded, dict):
+                            raise CameramodelParseException("yaml parsing did not generate a dictionary")
+                        return loaded
                     except Exception as e:
                         e1 = e
                         pass
 
                     try:
                         import json
-                        return json.loads(modelstring)
+                        loaded = json.loads(modelstring)
+                        if not isinstance(loaded, dict):
+                            raise CameramodelParseException("json parsing did not generate a dictionary")
+                        return loaded
                     except Exception as e:
                         e2 = e
                         pass


### PR DESCRIPTION
While loading a cahvore cameramodel, the yaml.safe_load function returns a str instead of a dict or raising an exception, causing issues later on. Suggest fix is to check whether the parsed result is a dict or not. I also tried parsing opencv and ros style examples that are in the same script and they parse without any problems