### PR TITLE
Replace malloc.h with stdlib.h

### DIFF
--- a/mrcal-image.c
+++ b/mrcal-image.c
@@ -7,7 +7,7 @@
 //     http://www.apache.org/licenses/LICENSE-2.0
 
 #include <FreeImage.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
`malloc.h` is deprecated; `stdlib.h` also provides `posix_memalign` (and `aligned_alloc` for that matter) and is more portable.