### PR TITLE
macOS support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ USE_LIBELAS ?= 0
 USE_LOCAL_STB_IMPLEMENTATION ?= $(COND_DARWIN)
 
 # convert all USE_XXX:=0 to an empty string
-$(foreach v,$(filter USE_%,$(.VARIABLES)),$(if $(filter 0,${$v}),$(eval undefine $v)))
+$(foreach v,$(filter USE_%,$(.VARIABLES)),$(if $(filter 0,${$v}),$(eval $v =)))
 # to print them all: $(foreach v,$(filter USE_%,$(.VARIABLES)),$(warning $v = '${$v}'))
 
 

--- a/Makefile
+++ b/Makefile
@@ -95,8 +95,8 @@ endif
 BIN_SOURCES +=					\
   test/test-gradients.c				\
   test/test-cahvor.c				\
-  test/test-lensmodel-string-manipulation.c     \
-  test/test-parser-cameramodel.c                \
+  test/test-lensmodel-string-manipulation.c	\
+  test/test-parser-cameramodel.c		\
   test/test-heap.c
 
 LDLIBS += -ldogleg $(if $(USE_LOCAL_STB_IMPLEMENTATION),,-lstb) -lpng -ljpeg -llapack
@@ -121,8 +121,8 @@ DIST_INCLUDE +=			\
 	poseutils.h		\
 	triangulation.h		\
 	types.h			\
-	stereo.h                \
-	heap.h                  \
+	stereo.h		\
+	heap.h			\
 	python-cameramodel-converter.h
 
 
@@ -148,9 +148,9 @@ DIST_BIN :=					\
 	mrcal-show-valid-intrinsics-region	\
 	mrcal-is-within-valid-intrinsics-region \
 	mrcal-triangulate			\
-	mrcal-cull-corners                      \
-	mrcal-show-residuals-board-observation  \
-	mrcal-show-residuals                    \
+	mrcal-cull-corners			\
+	mrcal-show-residuals-board-observation	\
+	mrcal-show-residuals			\
 	mrcal-stereo
 
 # generate manpages from distributed binaries, and ship them. This is a hoaky

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ LIB_SOURCES +=			\
 # be done
 python-cameramodel-converter.o: %.o:%.c
 	$(c_build_rule) && mv $@ _$@
-	$(OBJCOPY) --wildcard --weaken-symbol='Py*' --weaken-symbol='_Py*' _$@ $@ && mv $@ _$@
+	-$(OBJCOPY) --wildcard --weaken-symbol='Py*' --weaken-symbol='_Py*' _$@ $@ && mv $@ _$@
 	$(NM) -u _$@ | awk '$$1 == "U" && $$2 ~ "Py" { print $$2 }' > python-cameramodel-converter-py-symbol-refs
 	if [ -s python-cameramodel-converter-py-symbol-refs ]; then			\
 	  < python-cameramodel-converter-py-symbol-refs					\

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ LIB_SOURCES +=			\
 # libmrcal.so will not use this, so it should work without libpython. People
 # using this function will be doing so as part of PyArg_ParseTupleAndKeywords(),
 # so they will be linking to libpython anyway. Thus I weaken all the references
-# to libpython here. c_build_rule is the default logic in mrbuild
+# to libpython here, except on macOS. c_build_rule is the default logic in mrbuild
 #
 # This is a DEEP rabbithole. With Debian/trixie (released summer 2025) objcopy
 # --weaken works to weaken the symbols after compiling. With older objcopy (not
@@ -62,9 +62,14 @@ LIB_SOURCES +=			\
 # calling are not weakened. I catch this case here, and throw an error. In the
 # very near future, few people are going to have the too-old binutils, and we'll
 # be done
+#
+# On macOS, symbols must be associated with a dynamic library, but they can be
+# weakened when linking against that library. This makes most of the logic here
+# unnecessary, but requires extra linker options later.
 python-cameramodel-converter.o: %.o:%.c
-	$(c_build_rule) && mv $@ _$@
-	-$(OBJCOPY) --wildcard --weaken-symbol='Py*' --weaken-symbol='_Py*' _$@ $@ && mv $@ _$@
+	$(c_build_rule) $(if $(COND_DARWIN),,&& mv $@ _$@)
+ifeq ($(COND_DARWIN),) # not on macOS
+	$(OBJCOPY) --wildcard --weaken-symbol='Py*' --weaken-symbol='_Py*' _$@ $@ && mv $@ _$@
 	$(NM) -u _$@ | awk '$$1 == "U" && $$2 ~ "Py" { print $$2 }' > python-cameramodel-converter-py-symbol-refs
 	if [ -s python-cameramodel-converter-py-symbol-refs ]; then			\
 	  < python-cameramodel-converter-py-symbol-refs					\
@@ -79,6 +84,7 @@ python-cameramodel-converter.o: %.o:%.c
 	else										\
 	  mv _$@ $@;									\
 	fi
+endif
 EXTRA_CLEAN += \
   python-cameramodel-converter-py-symbol-refs   \
   python-cameramodel-converter-py-symbol-refs.h \
@@ -100,6 +106,11 @@ BIN_SOURCES +=					\
   test/test-heap.c
 
 LDLIBS += -ldogleg $(if $(USE_LOCAL_STB_IMPLEMENTATION),,-lstb) -lpng -ljpeg -llapack
+
+ifneq ($(COND_DARWIN),) # on macOS
+LDLIBS += -weak-lpython$(PY_LDVERSION)
+LDFLAGS += $(PY_MRBUILD_LDFLAGS)
+endif
 
 ifneq (${USE_LIBELAS},) # using libelas
 LDLIBS += -lelas


### PR DESCRIPTION
This fixes a number of errors I encountered when trying to build `mrcal` for macOS. The makefile syntax requirements were a bit stricter and required an extra pair of parentheses to parse successfully. The `USE_LIBELAS` flag wasn't implemented correctly and was always enabled, so I fixed it to actually compare against 0. `objcopy` doesn't exist on macOS (at least for arm64 binaries), but the backup symbol weakening procedure seemed to be a sufficient fallback so I allowed `objcopy` to fail. The `cholmod` include was updated to properly discover the include files from brew's `suitesparse`. The `stb` inclusion was updated to not depend on an external build by enabling the implementation in `image.c`. I also updated the `.gitignore` file to ignore generated and local-only files.

Besides adding the necessary include, library, and path directories to the make command, I also had to manually specify the Python library path and enable the Python library. I found this to be odd considering that the comments suggested that the Python library was only necessary if `mrcal` was imported from Python, and that `mrbuild` was already adding the same library path to `_PY_MRBUILD_LDFLAGS`. However, the build step linking together `libmrcal.dylib.5.0` would otherwise error due to undefined Python symbols.

There are still two failing test cases with these changes, but the vast majority of them pass. However, I had to manually copy the `libdogleg.dylib` over to the mrcal directory for it to be found. I have attached my [test results](https://github.com/user-attachments/files/24412922/mrcal-test-results.txt), best viewed through a terminal emulator since I captured the color escape sequences.
