### PR TITLE
Compiler compatibility fixes

### DIFF
--- a/_autodiff.hh
+++ b/_autodiff.hh
@@ -18,6 +18,7 @@
 #include <math.h>
 #include <string.h>
 #include "_strides.h"
+#include "_util.h"
 
 template<int NGRAD, int NVEC> struct vec_withgrad_t;
 
@@ -28,13 +29,13 @@ struct val_withgrad_t
     double x;
     double j[NGRAD];
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     val_withgrad_t(double _x = 0.0) : x(_x)
     {
         for(int i=0; i<NGRAD; i++) j[i] = 0.0;
     }
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     val_withgrad_t<NGRAD> operator+( const val_withgrad_t<NGRAD>& b ) const
     {
         val_withgrad_t<NGRAD> y = *this;
@@ -43,19 +44,19 @@ struct val_withgrad_t
             y.j[i] += b.j[i];
         return y;
     }
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     val_withgrad_t<NGRAD> operator+( double b ) const
     {
         val_withgrad_t<NGRAD> y = *this;
         y.x += b;
         return y;
     }
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     void operator+=( const val_withgrad_t<NGRAD>& b )
     {
         *this = (*this) + b;
     }
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     val_withgrad_t<NGRAD> operator-( const val_withgrad_t<NGRAD>& b ) const
     {
         val_withgrad_t<NGRAD> y = *this;
@@ -64,24 +65,24 @@ struct val_withgrad_t
             y.j[i] -= b.j[i];
         return y;
     }
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     val_withgrad_t<NGRAD> operator-( double b ) const
     {
         val_withgrad_t<NGRAD> y = *this;
         y.x -= b;
         return y;
     }
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     void operator-=( const val_withgrad_t<NGRAD>& b )
     {
         *this = (*this) - b;
     }
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     val_withgrad_t<NGRAD> operator-() const
     {
         return (*this) * (-1);
     }
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     val_withgrad_t<NGRAD> operator*( const val_withgrad_t<NGRAD>& b ) const
     {
         val_withgrad_t<NGRAD> y;
@@ -90,7 +91,7 @@ struct val_withgrad_t
             y.j[i] = j[i]*b.x + x*b.j[i];
         return y;
     }
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     val_withgrad_t<NGRAD> operator*( double b ) const
     {
         val_withgrad_t<NGRAD> y;
@@ -99,17 +100,17 @@ struct val_withgrad_t
             y.j[i] = j[i]*b;
         return y;
     }
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     void operator*=( const val_withgrad_t<NGRAD>& b )
     {
         *this = (*this) * b;
     }
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     void operator*=( const double b )
     {
         *this = (*this) * b;
     }
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     val_withgrad_t<NGRAD> operator/( const val_withgrad_t<NGRAD>& b ) const
     {
         val_withgrad_t<NGRAD> y;
@@ -118,22 +119,22 @@ struct val_withgrad_t
             y.j[i] = (j[i]*b.x - x*b.j[i]) / (b.x*b.x);
         return y;
     }
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     val_withgrad_t<NGRAD> operator/( double b ) const
     {
         return (*this) * (1./b);
     }
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     void operator/=( const val_withgrad_t<NGRAD>& b )
     {
         *this = (*this) / b;
     }
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     void operator/=( const double b )
     {
         *this = (*this) / b;
     }
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     val_withgrad_t<NGRAD> sqrt(void) const
     {
         val_withgrad_t<NGRAD> y;
@@ -143,7 +144,7 @@ struct val_withgrad_t
         return y;
     }
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     val_withgrad_t<NGRAD> square(void) const
     {
         val_withgrad_t<NGRAD> s;
@@ -153,7 +154,7 @@ struct val_withgrad_t
         return s;
     }
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     val_withgrad_t<NGRAD> sin(void) const
     {
         const double s = ::sin(x);
@@ -165,7 +166,7 @@ struct val_withgrad_t
         return y;
     }
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     val_withgrad_t<NGRAD> cos(void) const
     {
         const double s = ::sin(x);
@@ -177,7 +178,7 @@ struct val_withgrad_t
         return y;
     }
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     vec_withgrad_t<NGRAD, 2> sincos(void) const
     {
         const double s = ::sin(x);
@@ -193,7 +194,7 @@ struct val_withgrad_t
         return sc;
     }
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     val_withgrad_t<NGRAD> tan(void) const
     {
         const double s = ::sin(x);
@@ -205,7 +206,7 @@ struct val_withgrad_t
         return y;
     }
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     val_withgrad_t<NGRAD> atan2(val_withgrad_t<NGRAD>& x) const
     {
         val_withgrad_t<NGRAD> th;
@@ -226,7 +227,7 @@ struct val_withgrad_t
     // This function does NOT check for overflow. The gradient is infinite at
     // the valid bounds of the input. So the caller has to do the right thing in
     // those cases
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     val_withgrad_t<NGRAD> asin(void) const
     {
         val_withgrad_t<NGRAD> th;
@@ -240,7 +241,7 @@ struct val_withgrad_t
     // This function does NOT check for overflow. The gradient is infinite at
     // the valid bounds of the input. So the caller has to do the right thing in
     // those cases
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     val_withgrad_t<NGRAD> acos(void) const
     {
         val_withgrad_t<NGRAD> th;
@@ -251,7 +252,7 @@ struct val_withgrad_t
         return th;
     }
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     val_withgrad_t<NGRAD> sinx_over_x(// To avoid recomputing it
                                       const val_withgrad_t<NGRAD>& sinx) const
     {
@@ -285,7 +286,7 @@ struct vec_withgrad_t
 
     vec_withgrad_t() {}
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     void init_vars(const double* x_in, int ivar0, int Nvars, int i_gradvec0 = -1,
                    int stride = sizeof(double))
     {
@@ -305,31 +306,31 @@ struct vec_withgrad_t
         }
     }
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     vec_withgrad_t(const double* x_in, int i_gradvec0 = -1,
                    int stride = sizeof(double))
     {
         init_vars(x_in, 0, NVEC, i_gradvec0, stride);
     }
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     val_withgrad_t<NGRAD>& operator[](int i)
     {
         return v[i];
     }
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     const val_withgrad_t<NGRAD>& operator[](int i) const
     {
         return v[i];
     }
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     void operator+=( const vec_withgrad_t<NGRAD,NVEC>& x )
     {
         (*this) = (*this) + x;
     }
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     vec_withgrad_t<NGRAD,NVEC> operator+( const vec_withgrad_t<NGRAD,NVEC>& x ) const
     {
         vec_withgrad_t<NGRAD,NVEC> p;
@@ -338,12 +339,12 @@ struct vec_withgrad_t
         return p;
     }
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     void operator+=( const val_withgrad_t<NGRAD>& x )
     {
         (*this) = (*this) + x;
     }
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     vec_withgrad_t<NGRAD,NVEC> operator+( const val_withgrad_t<NGRAD>& x ) const
     {
         vec_withgrad_t<NGRAD,NVEC> p;
@@ -352,12 +353,12 @@ struct vec_withgrad_t
         return p;
     }
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     void operator+=( double x )
     {
         (*this) = (*this) + x;
     }
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     vec_withgrad_t<NGRAD,NVEC> operator+( double x ) const
     {
         vec_withgrad_t<NGRAD,NVEC> p;
@@ -366,12 +367,12 @@ struct vec_withgrad_t
         return p;
     }
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     void operator-=( const vec_withgrad_t<NGRAD,NVEC>& x )
     {
         (*this) = (*this) - x;
     }
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     vec_withgrad_t<NGRAD,NVEC> operator-( const vec_withgrad_t<NGRAD,NVEC>& x ) const
     {
         vec_withgrad_t<NGRAD,NVEC> p;
@@ -380,12 +381,12 @@ struct vec_withgrad_t
         return p;
     }
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     void operator-=( const val_withgrad_t<NGRAD>& x )
     {
         (*this) = (*this) - x;
     }
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     vec_withgrad_t<NGRAD,NVEC> operator-( const val_withgrad_t<NGRAD>& x ) const
     {
         vec_withgrad_t<NGRAD,NVEC> p;
@@ -394,12 +395,12 @@ struct vec_withgrad_t
         return p;
     }
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     void operator-=( double x )
     {
         (*this) = (*this) - x;
     }
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     vec_withgrad_t<NGRAD,NVEC> operator-( double x ) const
     {
         vec_withgrad_t<NGRAD,NVEC> p;
@@ -408,12 +409,12 @@ struct vec_withgrad_t
         return p;
     }
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     void operator*=( const vec_withgrad_t<NGRAD,NVEC>& x )
     {
         (*this) = (*this) * x;
     }
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     vec_withgrad_t<NGRAD,NVEC> operator*( const vec_withgrad_t<NGRAD,NVEC>& x ) const
     {
         vec_withgrad_t<NGRAD,NVEC> p;
@@ -422,12 +423,12 @@ struct vec_withgrad_t
         return p;
     }
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     void operator*=( const val_withgrad_t<NGRAD>& x )
     {
         (*this) = (*this) * x;
     }
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     vec_withgrad_t<NGRAD,NVEC> operator*( const val_withgrad_t<NGRAD>& x ) const
     {
         vec_withgrad_t<NGRAD,NVEC> p;
@@ -436,12 +437,12 @@ struct vec_withgrad_t
         return p;
     }
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     void operator*=( double x )
     {
         (*this) = (*this) * x;
     }
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     vec_withgrad_t<NGRAD,NVEC> operator*( double x ) const
     {
         vec_withgrad_t<NGRAD,NVEC> p;
@@ -450,12 +451,12 @@ struct vec_withgrad_t
         return p;
     }
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     void operator/=( const vec_withgrad_t<NGRAD,NVEC>& x )
     {
         (*this) = (*this) / x;
     }
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     vec_withgrad_t<NGRAD,NVEC> operator/( const vec_withgrad_t<NGRAD,NVEC>& x ) const
     {
         vec_withgrad_t<NGRAD,NVEC> p;
@@ -464,12 +465,12 @@ struct vec_withgrad_t
         return p;
     }
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     void operator/=( const val_withgrad_t<NGRAD>& x )
     {
         (*this) = (*this) / x;
     }
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     vec_withgrad_t<NGRAD,NVEC> operator/( const val_withgrad_t<NGRAD>& x ) const
     {
         vec_withgrad_t<NGRAD,NVEC> p;
@@ -478,12 +479,12 @@ struct vec_withgrad_t
         return p;
     }
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     void operator/=( double x )
     {
         (*this) = (*this) / x;
     }
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     vec_withgrad_t<NGRAD,NVEC> operator/( double x ) const
     {
         vec_withgrad_t<NGRAD,NVEC> p;
@@ -492,7 +493,7 @@ struct vec_withgrad_t
         return p;
     }
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     val_withgrad_t<NGRAD> dot( const vec_withgrad_t<NGRAD,NVEC>& x) const
     {
         val_withgrad_t<NGRAD> d; // initializes to 0
@@ -504,7 +505,7 @@ struct vec_withgrad_t
         return d;
     }
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     vec_withgrad_t<NGRAD,NVEC> cross( const vec_withgrad_t<NGRAD,NVEC>& x) const
     {
         vec_withgrad_t<NGRAD,NVEC> c;
@@ -514,20 +515,20 @@ struct vec_withgrad_t
         return c;
     }
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     val_withgrad_t<NGRAD> norm2(void) const
     {
         return dot(*this);
     }
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     val_withgrad_t<NGRAD> mag(void) const
     {
         val_withgrad_t<NGRAD> l2 = norm2();
         return l2.sqrt();
     }
 
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     void extract_value(double* out,
                        int stride = sizeof(double),
                        int ivar0 = 0, int Nvars = NVEC) const
@@ -535,7 +536,7 @@ struct vec_withgrad_t
         for(int i=ivar0; i<ivar0+Nvars; i++)
             _P1(out,stride, i-ivar0) = v[i].x;
     }
-    __attribute__ ((visibility ("hidden")))
+    MRCAL_HIDDEN
     void extract_grad(double* J,
                       int i_gradvec0, int N_gradout,
                       int ivar0,

--- a/_util.h
+++ b/_util.h
@@ -17,6 +17,14 @@ extern "C" {
 
 #define MSG(fmt, ...) fprintf(stderr, "%s(%d): " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__)
 
+#ifdef _MSC_VER
+#define MRCAL_HIDDEN
+#define MRCAL_UNUSED
+#else
+#define MRCAL_HIDDEN __attribute__((visibility ("hidden")))
+#define MRCAL_UNUSED __attribute__((unused))
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/basic-geometry.h
+++ b/basic-geometry.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "_util.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -95,40 +97,40 @@ typedef struct
 
 //////////// Easy convenience stuff
 ////// point2
-__attribute__((unused))
+MRCAL_UNUSED
 static double mrcal_point2_inner(const mrcal_point2_t a, const mrcal_point2_t b)
 {
     return
         a.x*b.x +
         a.y*b.y;
 }
-__attribute__((unused))
+MRCAL_UNUSED
 static double mrcal_point2_norm2(const mrcal_point2_t a)
 {
     return mrcal_point2_inner(a,a);
 }
 #define mrcal_point2_mag(a) sqrt(norm2(a)) // macro to not require #include <math.h>
 
-__attribute__((unused))
+MRCAL_UNUSED
 static mrcal_point2_t mrcal_point2_add(const mrcal_point2_t a, const mrcal_point2_t b)
 {
     return (mrcal_point2_t){ .x = a.x + b.x,
                              .y = a.y + b.y };
 }
-__attribute__((unused))
+MRCAL_UNUSED
 static mrcal_point2_t mrcal_point2_sub(const mrcal_point2_t a, const mrcal_point2_t b)
 {
     return (mrcal_point2_t){ .x = a.x - b.x,
                              .y = a.y - b.y };
 }
-__attribute__((unused))
+MRCAL_UNUSED
 static mrcal_point2_t mrcal_point2_scale(const mrcal_point2_t a, const double s)
 {
     return (mrcal_point2_t){ .x = a.x * s,
                              .y = a.y * s };
 }
 ////// point3
-__attribute__((unused))
+MRCAL_UNUSED
 static double mrcal_point3_inner(const mrcal_point3_t a, const mrcal_point3_t b)
 {
     return
@@ -136,35 +138,35 @@ static double mrcal_point3_inner(const mrcal_point3_t a, const mrcal_point3_t b)
         a.y*b.y +
         a.z*b.z;
 }
-__attribute__((unused))
+MRCAL_UNUSED
 static double mrcal_point3_norm2(const mrcal_point3_t a)
 {
     return mrcal_point3_inner(a,a);
 }
 #define mrcal_point3_mag(a) sqrt(mrcal_point3_norm2(a)) // macro to not require #include <math.h>
 
-__attribute__((unused))
+MRCAL_UNUSED
 static mrcal_point3_t mrcal_point3_add(const mrcal_point3_t a, const mrcal_point3_t b)
 {
     return (mrcal_point3_t){ .x = a.x + b.x,
                              .y = a.y + b.y,
                              .z = a.z + b.z };
 }
-__attribute__((unused))
+MRCAL_UNUSED
 static mrcal_point3_t mrcal_point3_sub(const mrcal_point3_t a, const mrcal_point3_t b)
 {
     return (mrcal_point3_t){ .x = a.x - b.x,
                              .y = a.y - b.y,
                              .z = a.z - b.z };
 }
-__attribute__((unused))
+MRCAL_UNUSED
 static mrcal_point3_t mrcal_point3_scale(const mrcal_point3_t a, const double s)
 {
     return (mrcal_point3_t){ .x = a.x * s,
                              .y = a.y * s,
                              .z = a.z * s };
 }
-__attribute__((unused))
+MRCAL_UNUSED
 static mrcal_point3_t mrcal_point3_cross(const mrcal_point3_t a, const mrcal_point3_t b)
 {
     return (mrcal_point3_t){ .x = a.y*b.z - a.z*b.y,

--- a/cahvore.cc
+++ b/cahvore.cc
@@ -10,6 +10,7 @@
 #include <assert.h>
 
 #include "_autodiff.hh"
+#include "_util.h"
 
 extern "C" {
 #include "_cahvore.h"
@@ -151,7 +152,7 @@ bool _project_cahvore_internals( // outputs
 // Not meant to be touched by the end user. Implemented separate from mrcal.c so
 // that I can get automated gradient propagation with c++
 extern "C"
-__attribute__ ((visibility ("hidden")))
+MRCAL_HIDDEN
 bool project_cahvore_internals( // outputs
                                 mrcal_point3_t* __restrict pdistorted,
                                 double*         __restrict dpdistorted_dintrinsics_nocore,

--- a/heap.h
+++ b/heap.h
@@ -13,7 +13,7 @@ mrcal_traverse_sensor_links(), but could potentially be useful somewhere
 on its own, so I'm exposing it here
  */
 
-
+#include <assert.h>
 #include <stdint.h>
 #include <stdbool.h>
 
@@ -23,13 +23,7 @@ typedef struct
     bool     done : 1;
     uint64_t cost : 47;
 } mrcal_heap_node_t;
-// I can't find a single static assertion invocation that works in both C++ and
-// C. The below is ugly, but works
-#ifdef __cplusplus
-static_assert( sizeof(mrcal_heap_node_t) == 8, "mrcal_heap_node_t has expected size");
-#else
-_Static_assert(sizeof(mrcal_heap_node_t) == 8, "mrcal_heap_node_t has expected size");
-#endif
+static_assert(sizeof(mrcal_heap_node_t) == 8, "mrcal_heap_node_t has expected size");
 
 typedef struct
 {

--- a/minimath/minimath-extra.h
+++ b/minimath/minimath-extra.h
@@ -1,5 +1,13 @@
 #pragma once
 
+#ifdef _MSC_VER
+#define MRCAL_HIDDEN
+#define MRCAL_UNUSED
+#else
+#define MRCAL_HIDDEN __attribute__((visibility ("hidden")))
+#define MRCAL_UNUSED __attribute__((unused))
+#endif
+
 // Extra functions I'm using in mrcal. I'm going to replace this whole library
 // eventually, to make things nicer. These new functions will be a part of the
 // replacement, and I'm not going to be thorough and I'm not going to add tests
@@ -7,7 +15,7 @@
 
 
 // Upper triangle is stored, in the usual row-major order.
-__attribute__((unused))
+MRCAL_UNUSED
 static
 int index_sym33(int i, int j)
 {
@@ -19,7 +27,7 @@ int index_sym33(int i, int j)
     if(i<=j) return (N*2-i-1)*i/2 + j;
     else     return (N*2-j-1)*j/2 + i;
 }
-__attribute__((unused))
+MRCAL_UNUSED
 static
 int index_sym33_assume_upper(int i, int j)
 {
@@ -28,7 +36,7 @@ int index_sym33_assume_upper(int i, int j)
 }
 
 // Upper triangle is stored, in the usual row-major order.
-__attribute__((unused))
+MRCAL_UNUSED
 static
 int index_sym66(int i, int j)
 {
@@ -40,14 +48,14 @@ int index_sym66(int i, int j)
     if(i<=j) return (N*2-i-1)*i/2 + j;
     else     return (N*2-j-1)*j/2 + i;
 }
-__attribute__((unused))
+MRCAL_UNUSED
 static
 int index_sym66_assume_upper(int i, int j)
 {
     const int N=6;
     return (N*2-i-1)*i/2 + j;
 }
-__attribute__((unused))
+MRCAL_UNUSED
 static
 void mul_gen33_gen33insym66(// output
                             double* restrict P, int P_strideelems0, int P_strideelems1,
@@ -70,7 +78,7 @@ void mul_gen33_gen33insym66(// output
         }
 }
 // Assumes the output is symmetric, and only computes the upper triangle
-__attribute__((unused))
+MRCAL_UNUSED
 static
 void mul_gen33_gen33_into33insym66_accum(// output
                                          double* restrict Psym66, int P_i0, int P_j0,
@@ -98,7 +106,7 @@ void mul_gen33_gen33_into33insym66_accum(// output
             }
         }
 }
-__attribute__((unused))
+MRCAL_UNUSED
 static
 void set_gen33_from_gen33insym66_accum(// output
                                        double* restrict P, int P_strideelems0, int P_strideelems1,
@@ -112,7 +120,7 @@ void set_gen33_from_gen33insym66_accum(// output
                 Msym66[index_sym66(iout+M_i0, jout+M_j0)] * scale;
 }
 // Assumes the output is symmetric, and only computes the upper triangle
-__attribute__((unused))
+MRCAL_UNUSED
 static
 void set_33insym66_from_gen33_accum(// output
                                     double* restrict Psym66, int P_i0, int P_j0,
@@ -152,7 +160,7 @@ void set_33insym66_from_gen33_accum(// output
 } while(0)
 
 // Matrix multiplication. Dimensions (N,L) <- (N,M) * (M,L)
-__attribute__((unused))
+MRCAL_UNUSED
 static
 void mul_genNM_genML(// output
                      double* restrict P, int P_strideelems0, int P_strideelems1,
@@ -164,7 +172,7 @@ void mul_genNM_genML(// output
 {
     _MUL_CORE(1);
 }
-__attribute__((unused))
+MRCAL_UNUSED
 static
 void mul_genNM_genML_accum(// output
                            double* restrict P, int P_strideelems0, int P_strideelems1,
@@ -189,7 +197,7 @@ void mul_genNM_genML_accum(// output
 #define mul_vec3t_gen33t(P,v,A,scale,ACCUM) mul_genNM_genML ## ACCUM(P,3,1, 1,3,3, v,3,1, A,1,3, scale)
 
 
-__attribute__((unused))
+MRCAL_UNUSED
 static inline void mul_vec6_sym66_scaled_strided(double* restrict v, int v_strideelems,
                                                  const double* restrict s,
                                                  const double scale)
@@ -203,7 +211,7 @@ static inline void mul_vec6_sym66_scaled_strided(double* restrict v, int v_strid
   v[5*v_strideelems] = (s[5]*t[0] + s[10]*t[1] + s[14]*t[2] + s[17]*t[3] + s[19]*t[4] + s[20]*v[5*v_strideelems]) * scale;
 }
 
-__attribute__((unused))
+MRCAL_UNUSED
 static inline void mul_genN6_sym66_scaled_strided(int n,
                                                   double* restrict v, int v_strideelems0, int v_strideelems1,
                                                   const double* restrict s,
@@ -214,3 +222,6 @@ static inline void mul_genN6_sym66_scaled_strided(int n,
                                     s,
                                     scale);
 }
+
+#undef MRCAL_UNUSED
+#undef MRCAL_HIDDEN

--- a/mrcal-pywrap.c
+++ b/mrcal-pywrap.c
@@ -8,6 +8,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 
+#include <assert.h>
 #include <stdbool.h>
 #include <Python.h>
 #include <structmember.h>
@@ -59,7 +60,7 @@ static PyObject* csr_from_cholmod_sparse( PyObject* P,
     }
 
     // Here I'm assuming specific types in my cholmod arrays. I tried to
-    // _Static_assert it, but internally cholmod uses void*, so I can't do that
+    // static_assert it, but internally cholmod uses void*, so I can't do that
     PyObject* MatrixDef = PyTuple_Pack(3, X, I, P);
     args                = PyTuple_Pack(1, MatrixDef);
     Py_DECREF(MatrixDef);
@@ -983,7 +984,7 @@ static bool optimize_validate_args( // out
                                     CROSS_REPROJECTION_CALLBACK_ARGUMENTS_OPTIONAL_EXTRA(ARG_LIST_DEFINE)
                                     void* dummy MRCAL_UNUSED)
 {
-    _Static_assert( sizeof(mrcal_pose_t)/sizeof(double) == 6, "mrcal_pose_t is assumed to contain 6 elements");
+    static_assert( sizeof(mrcal_pose_t)/sizeof(double) == 6, "mrcal_pose_t is assumed to contain 6 elements");
 
     OPTIMIZE_ARGUMENTS_REQUIRED(CHECK_LAYOUT);
     OPTIMIZE_ARGUMENTS_OPTIONAL(CHECK_LAYOUT);

--- a/mrcal-pywrap.c
+++ b/mrcal-pywrap.c
@@ -26,6 +26,7 @@
 #include "mrcal.h"
 #include "image.h"
 #include "stereo.h"
+#include "_util.h"
 
 #include "python-wrapping-utilities.h"
 
@@ -980,7 +981,7 @@ static bool optimize_validate_args( // out
                                     OPTIMIZE_ARGUMENTS_OPTIONAL(ARG_LIST_DEFINE)
                                     OPTIMIZER_CALLBACK_ARGUMENTS_OPTIONAL_EXTRA(ARG_LIST_DEFINE)
                                     CROSS_REPROJECTION_CALLBACK_ARGUMENTS_OPTIONAL_EXTRA(ARG_LIST_DEFINE)
-                                    void* dummy __attribute__((unused)))
+                                    void* dummy MRCAL_UNUSED)
 {
     _Static_assert( sizeof(mrcal_pose_t)/sizeof(double) == 6, "mrcal_pose_t is assumed to contain 6 elements");
 
@@ -3828,7 +3829,7 @@ PyObject* save_image(PyObject* NPY_UNUSED(self),
     _(R_cam0_rect0, PyArrayObject*, NULL, "O&", PyArray_Converter COMMA, R_cam0_rect0, NPY_DOUBLE, {3 COMMA 3 } )
 static bool
 rectified_resolution_validate_args(RECTIFIED_RESOLUTION_ARGUMENTS(ARG_LIST_DEFINE)
-                                   void* dummy __attribute__((unused)))
+                                   void* dummy MRCAL_UNUSED)
 {
     RECTIFIED_RESOLUTION_ARGUMENTS(CHECK_LAYOUT);
     return true;
@@ -3933,7 +3934,7 @@ PyObject* _rectified_resolution(PyObject* NPY_UNUSED(self),
     _(rt_cam1_ref, PyArrayObject*, NULL, "O&", PyArray_Converter COMMA, rt_cam1_ref, NPY_DOUBLE, {6 } )
 static bool
 rectified_system_validate_args(RECTIFIED_SYSTEM_ARGUMENTS(ARG_LIST_DEFINE)
-                               void* dummy __attribute__((unused)))
+                               void* dummy MRCAL_UNUSED)
 {
     RECTIFIED_SYSTEM_ARGUMENTS(CHECK_LAYOUT);
     return true;
@@ -4099,7 +4100,7 @@ PyObject* _rectified_system(PyObject* NPY_UNUSED(self),
 
 static bool
 rectification_maps_validate_args(RECTIFICATION_MAPS_ARGUMENTS(ARG_LIST_DEFINE)
-                                 void* dummy __attribute__((unused)))
+                                 void* dummy MRCAL_UNUSED)
 {
     RECTIFICATION_MAPS_ARGUMENTS(CHECK_LAYOUT);
     return true;

--- a/mrcal.c
+++ b/mrcal.c
@@ -9,6 +9,7 @@
 // Apparently I need this in MSVC to get constants
 #define _USE_MATH_DEFINES
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <inttypes.h>
@@ -312,7 +313,7 @@ static int LENSMODEL_SPLINED_STEREOGRAPHIC__lensmodel_num_params(const mrcal_LEN
 int mrcal_lensmodel_num_params(const mrcal_lensmodel_t* lensmodel)
 {
 #define CHECK_CONFIG_NPARAM_NOCONFIG(s,n) \
-    _Static_assert(n >= 0, "no-config implies known-at-compile-time param count");
+    static_assert(n >= 0, "no-config implies known-at-compile-time param count");
 
     switch(lensmodel->type)
     {
@@ -2674,8 +2675,8 @@ void project( // out
     if(!camera_at_identity)
     {
         // make sure I can pass mrcal_pose_t.r as an rt[] transformation
-        _Static_assert( offsetof(mrcal_pose_t, r) == 0,                   "mrcal_pose_t has expected structure");
-        _Static_assert( offsetof(mrcal_pose_t, t) == 3*sizeof(double),    "mrcal_pose_t has expected structure");
+        static_assert( offsetof(mrcal_pose_t, r) == 0,                   "mrcal_pose_t has expected structure");
+        static_assert( offsetof(mrcal_pose_t, t) == 3*sizeof(double),    "mrcal_pose_t has expected structure");
         mrcal_compose_rt( _joint_rt,
                           gg._d_rj_rc, gg._d_rj_rf,
                           gg._d_tj_rc, gg._d_tj_tf,
@@ -3458,8 +3459,8 @@ void mrcal_pack_solver_state_vector( // out, in
                                              lensmodel, problem_selections,
                                              Ncameras_intrinsics );
 
-    _Static_assert( offsetof(mrcal_pose_t, r) == 0,                   "mrcal_pose_t has expected structure");
-    _Static_assert( offsetof(mrcal_pose_t, t) == 3*sizeof(double),    "mrcal_pose_t has expected structure");
+    static_assert( offsetof(mrcal_pose_t, r) == 0,                   "mrcal_pose_t has expected structure");
+    static_assert( offsetof(mrcal_pose_t, t) == 3*sizeof(double),    "mrcal_pose_t has expected structure");
     if( problem_selections.do_optimize_extrinsics )
         for(int icam_extrinsics=0; icam_extrinsics < Ncameras_extrinsics; icam_extrinsics++)
         {
@@ -3708,9 +3709,9 @@ void mrcal_unpack_solver_state_vector( // out, in
 
     if( problem_selections.do_optimize_extrinsics )
     {
-        _Static_assert( offsetof(mrcal_pose_t, r) == 0,
+        static_assert( offsetof(mrcal_pose_t, r) == 0,
                        "mrcal_pose_t has expected structure");
-        _Static_assert( offsetof(mrcal_pose_t, t) == 3*sizeof(double),
+        static_assert( offsetof(mrcal_pose_t, t) == 3*sizeof(double),
                        "mrcal_pose_t has expected structure");
 
         mrcal_pose_t* rt_cam_ref = (mrcal_pose_t*)(&b[i_state]);
@@ -6186,9 +6187,9 @@ bool mrcal_optimizer_callback(// out
         .Npoints_fixed              = Npoints_fixed,
         .observations_board         = observations_board,
         .observations_board_pool    = observations_board_pool,
-        .observations_point_pool    = observations_point_pool,
         .Nobservations_board        = Nobservations_board,
         .observations_point         = observations_point,
+        .observations_point_pool    = observations_point_pool,
         .Nobservations_point        = Nobservations_point,
         .observations_point_triangulated  = observations_point_triangulated,
         .Nobservations_point_triangulated = Nobservations_point_triangulated,
@@ -6368,9 +6369,9 @@ mrcal_optimize( // out
         .Npoints_fixed              = Npoints_fixed,
         .observations_board         = observations_board,
         .observations_board_pool    = observations_board_pool,
-        .observations_point_pool    = observations_point_pool,
         .Nobservations_board        = Nobservations_board,
         .observations_point         = observations_point,
+        .observations_point_pool    = observations_point_pool,
         .Nobservations_point        = Nobservations_point,
         .observations_point_triangulated  = observations_point_triangulated,
         .Nobservations_point_triangulated = Nobservations_point_triangulated,

--- a/mrcal.h
+++ b/mrcal.h
@@ -21,6 +21,7 @@ extern "C" {
 #include "stereo.h"
 #include "triangulation.h"
 #include "image.h"
+#include "_util.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 //////////////////// Lens models
@@ -35,7 +36,7 @@ const char* const* mrcal_supported_lensmodel_names( void ); // NULL-terminated a
 
 
 // Return true if the given mrcal_lensmodel_type_t specifies a valid lens model
-__attribute__((unused))
+MRCAL_UNUSED
 static bool mrcal_lensmodel_type_is_valid(mrcal_lensmodel_type_t t)
 {
     return t >= 0;

--- a/test/test-harness.h
+++ b/test/test-harness.h
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdbool.h>
 #include <math.h>
+#include "../_util.h"
 
 #define GREEN       "\x1b[32m"
 #define RED         "\x1b[31m"
@@ -16,7 +17,7 @@
 int Ntests       = 0;
 int NtestsFailed = 0;
 
-__attribute__((unused))
+MRCAL_UNUSED
 static bool _confirm(bool x, const char* what_x, int where)
 {
     Ntests++;
@@ -36,7 +37,7 @@ static bool _confirm(bool x, const char* what_x, int where)
 }
 #define confirm(x) _confirm(x, #x, __LINE__)
 
-__attribute__((unused))
+MRCAL_UNUSED
 static bool _confirm_eq_int(int x, int xref, const char* what_x, const char* what_xref, int where)
 {
     Ntests++;
@@ -55,7 +56,7 @@ static bool _confirm_eq_int(int x, int xref, const char* what_x, const char* wha
 }
 #define confirm_eq_int(x,xref) _confirm_eq_int(x, xref, #x, #xref, __LINE__)
 
-__attribute__((unused))
+MRCAL_UNUSED
 static bool _confirm_eq_int_max_array(const int* x, const int* xref, int N, const char* what_x, const char* what_xref, int where)
 {
     Ntests++;
@@ -75,7 +76,7 @@ static bool _confirm_eq_int_max_array(const int* x, const int* xref, int N, cons
 #define confirm_eq_int_max_array(x,xref, N)                      \
     _confirm_eq_int_max_array(x, xref, N, #x, #xref, __LINE__)
 
-__attribute__((unused))
+MRCAL_UNUSED
 static void _confirm_eq_double(double x, double xref, const char* what_x, const char* what_xref, double eps, int where)
 {
     Ntests++;
@@ -91,7 +92,7 @@ static void _confirm_eq_double(double x, double xref, const char* what_x, const 
 #define confirm_eq_double(x,xref, eps) \
     _confirm_eq_double(x, xref, #x, #xref, eps, __LINE__)
 
-__attribute__((unused))
+MRCAL_UNUSED
 static bool _confirm_eq_double_max_array(const double* x, const double* xref, int N, const char* what_x, const char* what_xref, double eps, int where)
 {
     double worst_err = 0.0;

--- a/triangulation.cc
+++ b/triangulation.cc
@@ -7,6 +7,7 @@
 //     http://www.apache.org/licenses/LICENSE-2.0
 
 #include "_autodiff.hh"
+#include "_util.h"
 
 extern "C" {
 #include "triangulation.h"
@@ -762,7 +763,7 @@ mrcal_triangulate_leecivera_wmid2(// outputs
     return _m;
 }
 
-__attribute__((unused))
+MRCAL_UNUSED
 static
 val_withgrad_t<6>
 angle_error__assume_small(const vec_withgrad_t<6,3>& v0,
@@ -802,7 +803,7 @@ angle_error__assume_small(const vec_withgrad_t<6,3>& v0,
 #endif
 }
 
-__attribute__((unused))
+MRCAL_UNUSED
 static
 val_withgrad_t<6>
 angle_error__assume_small_arg0_normalized(const vec_withgrad_t<6,3>& v0,
@@ -836,7 +837,7 @@ angle_error__assume_small_arg0_normalized(const vec_withgrad_t<6,3>& v0,
 #endif
 }
 
-__attribute__((unused))
+MRCAL_UNUSED
 static
 val_withgrad_t<6>
 angle_error__assume_small_args_normalized(const vec_withgrad_t<6,3>& v0,
@@ -872,7 +873,7 @@ angle_error__assume_small_args_normalized(const vec_withgrad_t<6,3>& v0,
 #warning "triangulated-solve: maybe exposing the triangulated-error C function is OK? I'm already exposing the Python function"
 #endif
 
-__attribute__((unused))
+MRCAL_UNUSED
 static
 double relu(double x, double knee)
 {

--- a/types.h
+++ b/types.h
@@ -12,7 +12,7 @@
 extern "C" {
 #endif
 
-
+#include <assert.h>
 #include <stdint.h>
 #include <stdbool.h>
 
@@ -62,11 +62,7 @@ typedef struct {} mrcal_LENSMODEL_CAHVOR__config_t;
 
 #define _MRCAL_ITEM_DEFINE_ELEMENT(name, type, pybuildvaluecode, PRIcode,SCNcode, bitfield, cookie) type name bitfield;
 
-#ifndef __cplusplus
-// This barfs with g++ 4.8, so I disable it for C++ in general. Checking it for
-// C code is sufficient
-_Static_assert(sizeof(uint16_t) == sizeof(unsigned short int), "I need a short to be 16-bit. Py_BuildValue doesn't let me just specify that. H means 'unsigned short'");
-#endif
+static_assert(sizeof(uint16_t) == sizeof(unsigned short int), "I need a short to be 16-bit. Py_BuildValue doesn't let me just specify that. H means 'unsigned short'");
 
 // Configuration for CAHVORE. These are given as an an
 // "X macro": https://en.wikipedia.org/wiki/X_Macro


### PR DESCRIPTION
Can't use `__attribute__` on MSVC, so I replaced it with an ifdef'ed macro. `static_assert` was also giving me some trouble, so I used the lower case version, which is compatible with C++, and C with the assert.h header.